### PR TITLE
Challenge Student Grades Tracker 2 missing a method

### DIFF
--- a/challenges/student-grades-tracker-2/src/starter.rs
+++ b/challenges/student-grades-tracker-2/src/starter.rs
@@ -38,6 +38,10 @@ impl StudentGrades {
             student.add_grade(grade);
         }
     }
+
+    pub fn get_grades(&self, name: &str) -> &[u8] {
+        &self.students.get(name).unwrap().grades
+    }
 }
 
 pub fn main() {


### PR DESCRIPTION
In the Student Grades Tracker 2 challenge, we are asked to focus on adding two methods to the `Student` struct.

The `main` function calls a `get_grades()` method on the `tracker` object, which is not implemented.
Since we've already implemented it in the previous challenge (and no mention is made to adding this method), I'm assuming it should be included in `starter.rs`.