### PR TITLE
feat(cli): add no-editor flag to skip automatic editor opening after download

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -4,7 +4,10 @@ use clap::{Parser, Subcommand};
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::Get { command: get } => match get {
-            Get::Challenge { challenge } => get_challenge(&challenge).await,
+            Get::Challenge {
+                challenge,
+                no_editor,
+            } => get_challenge(&challenge, no_editor).await,
         },
         Commands::Submit => submit_challenge().await,
     }
@@ -40,5 +43,9 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum Get {
-    Challenge { challenge: String },
+    Challenge {
+        challenge: String,
+        #[clap(long, short = 'n')]
+        no_editor: bool,
+    },
 }

--- a/crates/cli/src/download.rs
+++ b/crates/cli/src/download.rs
@@ -13,7 +13,7 @@ const FILES: [&'static str; 4] = [
     "tests/tests.rs",
 ];
 
-pub async fn get_challenge(challenge: &str) -> anyhow::Result<()> {
+pub async fn get_challenge(challenge: &str, no_editor: bool) -> anyhow::Result<()> {
     if !challenge_exists(challenge).await? {
         println!("Challenge does not exist 🥺\n\nPlease make sure you've written the challenge name correctly.");
         return Ok(());
@@ -40,9 +40,10 @@ pub async fn get_challenge(challenge: &str) -> anyhow::Result<()> {
 
     // Check all results are successful
     if results.iter().all(Result::is_ok) {
-        // open it in the users editor
-        if let Some(editor) = Editor::find() {
-            editor.open(challenge);
+        if !no_editor {
+            if let Some(editor) = Editor::find() {
+                editor.open(challenge);
+            }
         }
 
         println!("Challenge downloaded 🥳");
@@ -119,7 +120,7 @@ mod tests {
             env::set_current_dir(&temp_path).ok();
 
             let test_challenge = |challenge: String| async move {
-                get_challenge(&challenge)
+                get_challenge(&challenge, true) // Use no_editor=true for tests
                     .await
                     .expect("Failed to download challenge");
 


### PR DESCRIPTION
This PR adds a --no-editor (-n) flag to the get challenge command, allowing users to download a challenge without opening it in an editor.

Changes include:

- CLI: Add no_editor flag and pass it to the command handler.
- Logic: Update get_challenge to skip opening the editor when no_editor is true.
- Tests: Adjust tests to use no_editor=true to avoid opening the editor during test runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line flag (`--no-editor` or `-n`) that allows users to fetch a challenge without automatically opening it in an editor.

- **Bug Fixes**
  - Improved automated tests to prevent the editor from opening during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->