### PR TITLE
added get_grades that was used in main of Student Grades Tracker 2 but wasn't implemented

### DIFF
--- a/challenges/student-grades-tracker-2/src/starter.rs
+++ b/challenges/student-grades-tracker-2/src/starter.rs
@@ -38,6 +38,10 @@ impl StudentGrades {
             student.add_grade(grade);
         }
     }
+
+    pub fn get_grades(&self, name: &str) -> &[u8] {
+        &self.students.get(name).unwrap().grades
+    }
 }
 
 pub fn main() {


### PR DESCRIPTION
See issue #107