### PR TITLE
Fix/plugin system

### DIFF
--- a/challenges/plugin-system/description.md
+++ b/challenges/plugin-system/description.md
@@ -23,7 +23,7 @@ Design and implement a plugin system using trait objects. You will:
     - `add_plugin` - Adds a plugin to the list.
     - `remove_plugin` - Removes a plugin from the list and returns the removed plugin if found.
     - `execute_all` - Executes all registered plugins.
-- If a duplicate plugin is added (with the same name), it should **panic** with the message "Plugin with name '<name>' already exists".
+- If a duplicate plugin is added (with the same name), it should **panic** with the message "Plugin with name {name} already exists".
 
 Make sure you make all relevant items public.
 

--- a/challenges/plugin-system/description.md
+++ b/challenges/plugin-system/description.md
@@ -23,7 +23,7 @@ Design and implement a plugin system using trait objects. You will:
     - `add_plugin` - Adds a plugin to the list.
     - `remove_plugin` - Removes a plugin from the list and returns the removed plugin if found.
     - `execute_all` - Executes all registered plugins.
-- If a duplicate plugin is added (with the same name), it should **panic** with the message "Plugin with name {name} already exists".
+- If a duplicate plugin is added (with the same name), it should **panic** with the message "Plugin with name {"{name}"} already exists".
 
 Make sure you make all relevant items public.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description of the panic message format for duplicate plugin additions to include double quotes around the plugin name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->