### PR TITLE
docs: fix spelling build-in -> built-in

### DIFF
--- a/challenges/constructors/description.md
+++ b/challenges/constructors/description.md
@@ -1,4 +1,4 @@
-Unlike other programming languages, Rust doesn't have a build-in `constructor` keyword to construct instances of a struct. Instead, you can directly create an instance of a struct simply by calling the struct's name and passing the required values.
+Unlike other programming languages, Rust doesn't have a built-in `constructor` keyword to construct instances of a struct. Instead, you can directly create an instance of a struct simply by calling the struct's name and passing the required values.
 
 ```rust
 struct Post {


### PR DESCRIPTION
Correct spelling _build-in_ to _built-in_ in Constructors challenge.